### PR TITLE
Remove execessive whitespace between titles and paragraphs

### DIFF
--- a/text.js
+++ b/text.js
@@ -2,7 +2,7 @@
 // Take a string argument 'description' and format it by replacing various HTML tags and whitespace characters
 function formatDescription (description) {
   return description
-    .replace(/<br><br>/g, '<br>')
+    .replace(/<br>+/g, '<br>')
     .replace(/<p>\s+/g, '<p>')
     .replace(/<br><p>/g, '<p>')
     .replace(/<br><\/p>/g, '</p>')


### PR DESCRIPTION
The html tags will automatically add newlines between headers and paragraphs. 

At the same time the newlines created by the multi-line strings are were also being included.

Should close: #13