### PR TITLE
fix: read group name from event sponsor instead of AEP root

### DIFF
--- a/action-network-event-ids.js
+++ b/action-network-event-ids.js
@@ -1,19 +1,31 @@
 /* eslint-disable no-unused-vars */
 
-// Fetch the group (AEP) title for an API key, used for safe log identification
-// in place of leaking part of the key. Falls back to a generic label if the
-// AEP request fails or the title is missing.
+// Fetch the sponsoring group's title for an API key, used for safe log
+// identification in place of leaking part of the key. The API entry point does
+// not expose a group name, so we read it from the `action_network:sponsor`
+// block on the first event the key can see. Results are cached per key for
+// the lifetime of the script run to avoid an extra request per log line.
+const _anGroupNameCache = {}
 function getANGroupName (apiKey) {
+  if (_anGroupNameCache[apiKey]) {
+    return _anGroupNameCache[apiKey]
+  }
+  let name = '(unknown group)'
   try {
-    const response = UrlFetchApp.fetch(apiUrlAn, standardApiParameters(apiKey))
-    const title = JSON.parse(response).title
-    if (title) {
-      return title
+    const response = UrlFetchApp.fetch(`${apiUrlAn}events/?per_page=1`, standardApiParameters(apiKey))
+    const events = (JSON.parse(response)._embedded || {})['osdi:events'] || []
+    for (const event of events) {
+      const sponsor = event['action_network:sponsor']
+      if (sponsor && sponsor.title) {
+        name = sponsor.title
+        break
+      }
     }
   } catch (err) {
-    console.warn(`Could not fetch group name from Action Network AEP: ${err}`)
+    console.warn(`Could not fetch group name from Action Network: ${err}`)
   }
-  return '(unknown group)'
+  _anGroupNameCache[apiKey] = name
+  return name
 }
 
 // This function returns events from Action Network. If a filter is provided, it appends it to the API URL.


### PR DESCRIPTION
Follow-up to #25 / #21.

@bmos pointed out the previous fix was hitting the wrong endpoint: the API entry point (`/api/v2/`) doesn't expose the group's name, so `getANGroupName` was always falling through to `(unknown group)`.

### Where the group name actually lives

Per the [Action Network OSDI v2 docs](https://actionnetwork.org/docs/v2/events), each event resource has an `action_network:sponsor` block with `title` documented as "the name of the sponsoring group."

### Change

`getANGroupName(apiKey)` now:

1. Fetches `events/?per_page=1` with the API key.
2. Reads `_embedded["osdi:events"][i]["action_network:sponsor"].title`, walking the page so a first event missing the sponsor block doesn't poison the result.
3. Caches the resolved name per `apiKey` so log lines later in the same run don't trigger another HTTP request.
4. Falls back to `(unknown group)` on network failure, empty event list, missing `_embedded`, missing sponsor, or missing `sponsor.title`.

One file touched (`action-network-event-ids.js`), no API changes, no new globals.

### Verification

- `npx standard action-network-event-ids.js` clean.
- Smoke-tested locally with mocked `UrlFetchApp.fetch` against six payload shapes (happy path, sponsor-on-second-event, missing title, empty list, malformed payload, fetch throws). All resolved as expected and cache hit count was 1 for repeat calls.

### Known limitation

If a group has zero events visible to the key, or every event was imported via a path that strips the sponsor block, we still log `(unknown group)`. Strictly better than the current 100% fallback rate, and the underlying goal (don't log key fragments) holds in every branch.